### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ For more information and documentation, visit [altcha.org](https://altcha.org).
 With npm:
 
 ```bash
-npm install altcha-react-native
+npm install react-native-altcha
 ```
 
 Or with Yarn:
 
 ```bash
-yarn add altcha-react-native
+yarn add react-native-altcha
 ```
 
 If your project uses Expo, no extra native setup is needed.
@@ -58,7 +58,7 @@ If you are using bare React Native, you may need to run `pod install`.
 ```jsx
 import React from 'react';
 import { View } from 'react-native';
-import { AltchaWidget } from 'altcha-react-native';
+import { AltchaWidget } from 'react-native-altcha';
 
 export default function App() {
   return (

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ For more information and documentation, visit [altcha.org](https://altcha.org).
 
 ## Installation
 
+Install peer dependencies
+
+```
+npx expo install expo-audio expo-crypto expo-localization react-native-svg
+```
+
 With npm:
 
 ```bash
@@ -49,9 +55,6 @@ Or with Yarn:
 ```bash
 yarn add react-native-altcha
 ```
-
-If your project uses Expo, no extra native setup is needed.
-If you are using bare React Native, you may need to run `pod install`.
 
 ## Usage
 
@@ -163,8 +166,8 @@ type AltchaTheme = {
 
 ```bash
 cd example
-npm install
-npm start
+yarn install
+yarn start
 ```
 
 ## License

--- a/example/app.json
+++ b/example/app.json
@@ -26,6 +26,10 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "expo-audio",
+      "expo-localization"
+    ]
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -12,11 +12,15 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@expo/metro-runtime": "~5.0.4",
     "expo": "~53.0.20",
+    "expo-audio": "~0.4.9",
+    "expo-crypto": "~14.1.5",
+    "expo-localization": "~16.1.6",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-safe-area-context": "^5.6.0",
+    "react-native-svg": "15.11.2",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,18 +78,28 @@
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.3",
+    "expo": "~53.0.0",
+    "expo-audio": "~0.4.8",
+    "expo-crypto": "~14.1.5",
+    "expo-localization": "~16.1.6",
     "jest": "^29.7.0",
     "prettier": "^3.0.3",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-builder-bob": "^0.40.13",
+    "react-native-svg": "^15.12.1",
     "react-test-renderer": "19.0.0",
     "release-it": "^19.0.4",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
+    "expo": ">=50",
+    "expo-audio": ">=0.4.0",
+    "expo-crypto": ">=14.0.0",
+    "expo-localization": ">=16.0.0",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-svg": ">=15"
   },
   "workspaces": [
     "example"
@@ -161,12 +171,5 @@
     "languages": "js",
     "type": "library",
     "version": "0.52.0"
-  },
-  "dependencies": {
-    "expo": "~53.0.0",
-    "expo-audio": "~0.4.8",
-    "expo-crypto": "~14.1.5",
-    "expo-localization": "~16.1.6",
-    "react-native-svg": "^15.12.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7007,6 +7007,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-audio@npm:~0.4.9":
+  version: 0.4.9
+  resolution: "expo-audio@npm:0.4.9"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+  checksum: e61ad2fc47441bcbe51dfce3fe0c4cbd4b64c40878ecbc3202674f9ac98a24b5a03824f3cdd54b63d3fa17df59fe7dc69241144d389008fd52f42beedf175988
+  languageName: node
+  linkType: hard
+
 "expo-constants@npm:~17.1.7":
   version: 17.1.7
   resolution: "expo-constants@npm:17.1.7"
@@ -11797,6 +11808,9 @@ __metadata:
     "@babel/plugin-proposal-export-namespace-from": ^7.18.9
     "@expo/metro-runtime": ~5.0.4
     expo: ~53.0.20
+    expo-audio: ~0.4.9
+    expo-crypto: ~14.1.5
+    expo-localization: ~16.1.6
     expo-status-bar: ~2.2.3
     react: 19.0.0
     react-dom: 19.0.0
@@ -11804,6 +11818,7 @@ __metadata:
     react-native-builder-bob: ^0.40.13
     react-native-monorepo-config: ^0.1.9
     react-native-safe-area-context: ^5.6.0
+    react-native-svg: 15.11.2
     react-native-web: ~0.20.0
   languageName: unknown
   linkType: soft
@@ -11843,8 +11858,13 @@ __metadata:
     release-it: ^19.0.4
     typescript: ^5.8.3
   peerDependencies:
+    expo: ">=50"
+    expo-audio: ">=0.4.0"
+    expo-crypto: ">=14.0.0"
+    expo-localization: ">=16.0.0"
     react: "*"
     react-native: "*"
+    react-native-svg: ">=15"
   languageName: unknown
   linkType: soft
 
@@ -11917,6 +11937,20 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 23f382a6504dc6ff1064fe45af53207014a27d3312eeaa5e0fd92281c425cb518d7e5e7bc79cf29b0f8e685a30931df93800dfe98e5d81bd768499aa5e737ab0
+  languageName: node
+  linkType: hard
+
+"react-native-svg@npm:15.11.2":
+  version: 15.11.2
+  resolution: "react-native-svg@npm:15.11.2"
+  dependencies:
+    css-select: ^5.1.0
+    css-tree: ^1.1.3
+    warn-once: 0.1.1
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 7bc2d9a5b7ceb66905e358d995bf102d63ce017db40b024d31a6ada03c21733fd3620f9ad867d631b878e2380033ea8777e75c4f654bc5b420ea902695ed9ba8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,6 +2029,78 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/cli@npm:0.24.21":
+  version: 0.24.21
+  resolution: "@expo/cli@npm:0.24.21"
+  dependencies:
+    "@0no-co/graphql.web": ^1.0.8
+    "@babel/runtime": ^7.20.0
+    "@expo/code-signing-certificates": ^0.0.5
+    "@expo/config": ~11.0.13
+    "@expo/config-plugins": ~10.1.2
+    "@expo/devcert": ^1.1.2
+    "@expo/env": ~1.0.7
+    "@expo/image-utils": ^0.7.6
+    "@expo/json-file": ^9.1.5
+    "@expo/metro-config": ~0.20.17
+    "@expo/osascript": ^2.2.5
+    "@expo/package-manager": ^1.8.6
+    "@expo/plist": ^0.3.5
+    "@expo/prebuild-config": ^9.0.11
+    "@expo/schema-utils": ^0.1.0
+    "@expo/spawn-async": ^1.7.2
+    "@expo/ws-tunnel": ^1.0.1
+    "@expo/xcpretty": ^4.3.0
+    "@react-native/dev-middleware": 0.79.6
+    "@urql/core": ^5.0.6
+    "@urql/exchange-retry": ^1.3.0
+    accepts: ^1.3.8
+    arg: ^5.0.2
+    better-opn: ~3.0.2
+    bplist-creator: 0.1.0
+    bplist-parser: ^0.3.1
+    chalk: ^4.0.0
+    ci-info: ^3.3.0
+    compression: ^1.7.4
+    connect: ^3.7.0
+    debug: ^4.3.4
+    env-editor: ^0.4.1
+    freeport-async: ^2.0.0
+    getenv: ^2.0.0
+    glob: ^10.4.2
+    lan-network: ^0.1.6
+    minimatch: ^9.0.0
+    node-forge: ^1.3.1
+    npm-package-arg: ^11.0.0
+    ora: ^3.4.0
+    picomatch: ^3.0.1
+    pretty-bytes: ^5.6.0
+    pretty-format: ^29.7.0
+    progress: ^2.0.3
+    prompts: ^2.3.2
+    qrcode-terminal: 0.11.0
+    require-from-string: ^2.0.2
+    requireg: ^0.2.2
+    resolve: ^1.22.2
+    resolve-from: ^5.0.0
+    resolve.exports: ^2.0.3
+    semver: ^7.6.0
+    send: ^0.19.0
+    slugify: ^1.3.4
+    source-map-support: ~0.5.21
+    stacktrace-parser: ^0.1.10
+    structured-headers: ^0.4.1
+    tar: ^7.4.3
+    terminal-link: ^2.1.1
+    undici: ^6.18.2
+    wrap-ansi: ^7.0.0
+    ws: ^8.12.1
+  bin:
+    expo-internal: build/bin/cli
+  checksum: 1dc76964a763427440a9d76786e8e20c0f0f264783376f333be3a092bf8468264b65e0ac9c8ebdb90ea2c3cccb8b0cf080aca6284fc54c414742551acbe07528
+  languageName: node
+  linkType: hard
+
 "@expo/code-signing-certificates@npm:^0.0.5":
   version: 0.0.5
   resolution: "@expo/code-signing-certificates@npm:0.0.5"
@@ -2248,6 +2320,13 @@ __metadata:
     semver: ^7.6.0
     xml2js: 0.6.0
   checksum: 1d61451073095edef41f3224ee8f0b2399d305a108ef87fff92f59107796b053b8b55676358cf4c6bc5bcc84c818083a4324204521979c3f52bf24d5fe4f3d96
+  languageName: node
+  linkType: hard
+
+"@expo/schema-utils@npm:^0.1.0":
+  version: 0.1.6
+  resolution: "@expo/schema-utils@npm:0.1.6"
+  checksum: 7535356fab40eaff4665604bc345dcb97f5daab4ed3702b5adf8304654ea890eabab3adcaef54e817642663dd3f2a5a73f338799da1ee61f85c8666552a257a6
   languageName: node
   linkType: hard
 
@@ -3247,6 +3326,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/babel-plugin-codegen@npm:0.79.6":
+  version: 0.79.6
+  resolution: "@react-native/babel-plugin-codegen@npm:0.79.6"
+  dependencies:
+    "@babel/traverse": ^7.25.3
+    "@react-native/codegen": 0.79.6
+  checksum: 7d25679bf31a1544c3031d78ce569f24cb5b9b011149d120d2e676e20d138e153a384495060b821e3fc440f08ce8f2627170016a3049824f402043fba1fdc7f5
+  languageName: node
+  linkType: hard
+
 "@react-native/babel-preset@npm:0.78.2":
   version: 0.78.2
   resolution: "@react-native/babel-preset@npm:0.78.2"
@@ -3357,6 +3446,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/babel-preset@npm:0.79.6":
+  version: 0.79.6
+  resolution: "@react-native/babel-preset@npm:0.79.6"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/plugin-proposal-export-default-from": ^7.24.7
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-default-from": ^7.24.7
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-transform-arrow-functions": ^7.24.7
+    "@babel/plugin-transform-async-generator-functions": ^7.25.4
+    "@babel/plugin-transform-async-to-generator": ^7.24.7
+    "@babel/plugin-transform-block-scoping": ^7.25.0
+    "@babel/plugin-transform-class-properties": ^7.25.4
+    "@babel/plugin-transform-classes": ^7.25.4
+    "@babel/plugin-transform-computed-properties": ^7.24.7
+    "@babel/plugin-transform-destructuring": ^7.24.8
+    "@babel/plugin-transform-flow-strip-types": ^7.25.2
+    "@babel/plugin-transform-for-of": ^7.24.7
+    "@babel/plugin-transform-function-name": ^7.25.1
+    "@babel/plugin-transform-literals": ^7.25.2
+    "@babel/plugin-transform-logical-assignment-operators": ^7.24.7
+    "@babel/plugin-transform-modules-commonjs": ^7.24.8
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.24.7
+    "@babel/plugin-transform-nullish-coalescing-operator": ^7.24.7
+    "@babel/plugin-transform-numeric-separator": ^7.24.7
+    "@babel/plugin-transform-object-rest-spread": ^7.24.7
+    "@babel/plugin-transform-optional-catch-binding": ^7.24.7
+    "@babel/plugin-transform-optional-chaining": ^7.24.8
+    "@babel/plugin-transform-parameters": ^7.24.7
+    "@babel/plugin-transform-private-methods": ^7.24.7
+    "@babel/plugin-transform-private-property-in-object": ^7.24.7
+    "@babel/plugin-transform-react-display-name": ^7.24.7
+    "@babel/plugin-transform-react-jsx": ^7.25.2
+    "@babel/plugin-transform-react-jsx-self": ^7.24.7
+    "@babel/plugin-transform-react-jsx-source": ^7.24.7
+    "@babel/plugin-transform-regenerator": ^7.24.7
+    "@babel/plugin-transform-runtime": ^7.24.7
+    "@babel/plugin-transform-shorthand-properties": ^7.24.7
+    "@babel/plugin-transform-spread": ^7.24.7
+    "@babel/plugin-transform-sticky-regex": ^7.24.7
+    "@babel/plugin-transform-typescript": ^7.25.2
+    "@babel/plugin-transform-unicode-regex": ^7.24.7
+    "@babel/template": ^7.25.0
+    "@react-native/babel-plugin-codegen": 0.79.6
+    babel-plugin-syntax-hermes-parser: 0.25.1
+    babel-plugin-transform-flow-enums: ^0.0.2
+    react-refresh: ^0.14.0
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 60e32dcefefffa9e2d936bcea5bd4dbc661dcaa3254f12eca42eb47a7184b5a99a10ceee0a3eb787991200659cfb8093f02578b0e0e521e0268b5e2df911f588
+  languageName: node
+  linkType: hard
+
 "@react-native/codegen@npm:0.78.2":
   version: 0.78.2
   resolution: "@react-native/codegen@npm:0.78.2"
@@ -3389,6 +3533,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/codegen@npm:0.79.6":
+  version: 0.79.6
+  resolution: "@react-native/codegen@npm:0.79.6"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/parser": ^7.25.3
+    glob: ^7.1.1
+    hermes-parser: 0.25.1
+    invariant: ^2.2.4
+    nullthrows: ^1.1.1
+    yargs: ^17.6.2
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: eeae52acd9b7c82f85ba8dcdee07731e845eef45611e4b296062c8ce12e3a588b8fa6df4771d07257db59dd88490c44675791ccf31a925f1171bb9128895caf8
+  languageName: node
+  linkType: hard
+
 "@react-native/community-cli-plugin@npm:0.79.5":
   version: 0.79.5
   resolution: "@react-native/community-cli-plugin@npm:0.79.5"
@@ -3417,6 +3578,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/debugger-frontend@npm:0.79.6":
+  version: 0.79.6
+  resolution: "@react-native/debugger-frontend@npm:0.79.6"
+  checksum: 1d6d02816843f02925fc3752534111503a0892c0a60df52c81861a183ac8f72d1bc9a788826d97b9faf677faa1d700addcbfc4310f881e112f9daf1d46770689
+  languageName: node
+  linkType: hard
+
 "@react-native/dev-middleware@npm:0.79.5":
   version: 0.79.5
   resolution: "@react-native/dev-middleware@npm:0.79.5"
@@ -3433,6 +3601,25 @@ __metadata:
     serve-static: ^1.16.2
     ws: ^6.2.3
   checksum: 0d2bd347060021287a3b47f37f7f942cda37be7cd58b51fb0aaa5ab3fe1ecc1359adc7cc845c70f301ad9a87731eb3cf91a66b09c15519393013378f16285c95
+  languageName: node
+  linkType: hard
+
+"@react-native/dev-middleware@npm:0.79.6":
+  version: 0.79.6
+  resolution: "@react-native/dev-middleware@npm:0.79.6"
+  dependencies:
+    "@isaacs/ttlcache": ^1.4.1
+    "@react-native/debugger-frontend": 0.79.6
+    chrome-launcher: ^0.15.2
+    chromium-edge-launcher: ^0.2.0
+    connect: ^3.6.5
+    debug: ^2.2.0
+    invariant: ^2.2.4
+    nullthrows: ^1.1.1
+    open: ^7.0.3
+    serve-static: ^1.16.2
+    ws: ^6.2.3
+  checksum: 264eec70a4cf0ad4c462387cf9f5cb7187a70ee86123f2888a7e09b12108eb26b4f1315115f37f5db894d306f033501b71d8662c97a061be96661d78b3491a60
   languageName: node
   linkType: hard
 
@@ -4591,6 +4778,40 @@ __metadata:
     babel-plugin-react-compiler:
       optional: true
   checksum: 3d95975e5a871de9a694468bedd88732859b71fb6ef1b99dc0deddd677f798e0c38211820ef0a08608d53c1307790da999fdd4564473cca6c3802a09d925d876
+  languageName: node
+  linkType: hard
+
+"babel-preset-expo@npm:~13.2.4":
+  version: 13.2.4
+  resolution: "babel-preset-expo@npm:13.2.4"
+  dependencies:
+    "@babel/helper-module-imports": ^7.25.9
+    "@babel/plugin-proposal-decorators": ^7.12.9
+    "@babel/plugin-proposal-export-default-from": ^7.24.7
+    "@babel/plugin-syntax-export-default-from": ^7.24.7
+    "@babel/plugin-transform-export-namespace-from": ^7.25.9
+    "@babel/plugin-transform-flow-strip-types": ^7.25.2
+    "@babel/plugin-transform-modules-commonjs": ^7.24.8
+    "@babel/plugin-transform-object-rest-spread": ^7.24.7
+    "@babel/plugin-transform-parameters": ^7.24.7
+    "@babel/plugin-transform-private-methods": ^7.24.7
+    "@babel/plugin-transform-private-property-in-object": ^7.24.7
+    "@babel/plugin-transform-runtime": ^7.24.7
+    "@babel/preset-react": ^7.22.15
+    "@babel/preset-typescript": ^7.23.0
+    "@react-native/babel-preset": 0.79.6
+    babel-plugin-react-native-web: ~0.19.13
+    babel-plugin-syntax-hermes-parser: ^0.25.1
+    babel-plugin-transform-flow-enums: ^0.0.2
+    debug: ^4.3.4
+    react-refresh: ^0.14.2
+    resolve-from: ^5.0.0
+  peerDependencies:
+    babel-plugin-react-compiler: ^19.0.0-beta-e993439-20250405
+  peerDependenciesMeta:
+    babel-plugin-react-compiler:
+      optional: true
+  checksum: 9a247129e7bef0874b33e8b8088006bf3df4233b8738485d9ab998336ed200063f791aa5071db24debade39e5ac8cb41c41e0772f84f5f491b85fc89642b3438
   languageName: node
   linkType: hard
 
@@ -6893,7 +7114,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo@npm:~53.0.0, expo@npm:~53.0.20":
+"expo@npm:~53.0.0":
+  version: 53.0.22
+  resolution: "expo@npm:53.0.22"
+  dependencies:
+    "@babel/runtime": ^7.20.0
+    "@expo/cli": 0.24.21
+    "@expo/config": ~11.0.13
+    "@expo/config-plugins": ~10.1.2
+    "@expo/fingerprint": 0.13.4
+    "@expo/metro-config": 0.20.17
+    "@expo/vector-icons": ^14.0.0
+    babel-preset-expo: ~13.2.4
+    expo-asset: ~11.1.7
+    expo-constants: ~17.1.7
+    expo-file-system: ~18.1.11
+    expo-font: ~13.3.2
+    expo-keep-awake: ~14.1.4
+    expo-modules-autolinking: 2.1.14
+    expo-modules-core: 2.5.0
+    react-native-edge-to-edge: 1.6.0
+    whatwg-url-without-unicode: 8.0.0-3
+  peerDependencies:
+    "@expo/dom-webview": "*"
+    "@expo/metro-runtime": "*"
+    react: "*"
+    react-native: "*"
+    react-native-webview: "*"
+  peerDependenciesMeta:
+    "@expo/dom-webview":
+      optional: true
+    "@expo/metro-runtime":
+      optional: true
+    react-native-webview:
+      optional: true
+  bin:
+    expo: bin/cli
+    expo-modules-autolinking: bin/autolinking
+    fingerprint: bin/fingerprint
+  checksum: d425dcad1e9fda7e8fc15f0410f2f4a0e03bdfdd33ea6d7adba96dab5007a1bf41aad65d4e6c4362e3aba7b1a29fb10487713ff5e474c03b781653f8128badd2
+  languageName: node
+  linkType: hard
+
+"expo@npm:~53.0.20":
   version: 53.0.20
   resolution: "expo@npm:53.0.20"
   dependencies:


### PR DESCRIPTION
Thanks for creating this library. I'm evaluating using altcha for my React Native app and it seems a good fit. However, there's a clash with native dependencies when installing the library (my app is currently on Expo 53, but not exact same versions of the expo dependencies).

This pull request changes the dependency setup so the expo dependencies and react-native-svg are peer dependencies with wider version ranges so the library can be used without having to match exact dependency versions.

This PR also includes a fix for the package name in the README, which was referenced as "altcha-react-native" instead of "react-native-altcha".